### PR TITLE
Add route to check if person is contactable

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ LOCAL_ELASTICSEARCH = False
 Running tests
 --------------
 
-For testing you need to run ```./manage.py test nuntium contactos mailit```
+For testing you need to run ```./manage.py test nuntium contactos mailit instance```
 
 Coverage Analysis
 -----------------

--- a/README.md
+++ b/README.md
@@ -284,4 +284,4 @@ The github repos and the status of the development are listed below:
 
 There are instructions to install write-it in heroku
 ----------------------------------------------------
-The instructions are in [the following link](deploying_to_heroku.md).
+The instructions are in [the following link](deploying_to_heroku.md). 

--- a/example_data.yaml
+++ b/example_data.yaml
@@ -89,7 +89,14 @@
     deleted_from_source: false
     content_type: [popolo, person]
     object_id: 3
-  pk: 2
+  pk: 3
+- model: popolo_sources.linktopopolosource
+  fields:
+    popolo_source: 2
+    deleted_from_source: false
+    content_type: [popolo, person]
+    object_id: 4
+  pk: 4
 
 
 - fields: {name: Pedro}
@@ -101,6 +108,9 @@
 - fields: {name: Felipe}
   model: popolo.person
   pk: 3
+- fields: {name: Philippa}
+  model: popolo.person
+  pk: 4
 - fields: {name: 'Fake Parliament', classification: 'legislature'}
   model: popolo.organization
   pk: 1
@@ -194,6 +204,27 @@
     scheme: popolo:person
   model: popolo.identifier
   pk: 9
+- fields:
+    content_type: [popolo, person]
+    identifier: 52xc7ardasd34569
+    object_id: 4
+    scheme: popit_id
+  model: popolo.identifier
+  pk: 10
+- fields:
+    content_type: [popolo, person]
+    identifier: http://popit.mysociety.org/api/v1/persons/4
+    object_id: 4
+    scheme: popit_url
+  model: popolo.identifier
+  pk: 11
+- fields:
+    content_type: [popolo, person]
+    identifier: 52xc7ardasd34569
+    object_id: 4
+    scheme: popolo:person
+  model: popolo.identifier
+  pk: 12
 - fields: {content: Public Answer,message: 2,person: 1}
   model: nuntium.answer
   pk: 1

--- a/instance/models.py
+++ b/instance/models.py
@@ -7,7 +7,7 @@ from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.core import mail
 from django.db import models, transaction
-from django.db.models import Prefetch
+from django.db.models import Prefetch, Count
 from django.db.models.signals import post_save
 from django.utils.translation import ugettext_lazy as _
 
@@ -27,6 +27,13 @@ from mailit import MailChannel
 
 
 class PopoloPersonQuerySet(models.QuerySet):
+    def has_contacts(self):
+        contact_count = Count("contact")
+        return self.annotate(contact_count=contact_count).filter(contact_count__gte=1)
+
+    def doesnt_have_contacts(self):
+        contact_count = Count("contact")
+        return self.annotate(contact_count=contact_count).filter(contact_count__lt=1)
 
     def get_from_api_uri(self, uri_from_api):
         return self.get(

--- a/instance/models.py
+++ b/instance/models.py
@@ -75,6 +75,10 @@ class PopoloPerson(Person):
     def popolo_source_url(self):
         return self.popolo_source.url
 
+    @property
+    def contactable(self):
+        return Contact.are_there_contacts_for(self)
+
     # Note that these methods use the slightly odd implementation
     # of iterating over the relation rather than using .filter or .get
     # because if they're preloaded with prefetch_related those methods

--- a/instance/models.py
+++ b/instance/models.py
@@ -75,10 +75,6 @@ class PopoloPerson(Person):
     def popolo_source_url(self):
         return self.popolo_source.url
 
-    @property
-    def contactable(self):
-        return Contact.are_there_contacts_for(self)
-
     # Note that these methods use the slightly odd implementation
     # of iterating over the relation rather than using .filter or .get
     # because if they're preloaded with prefetch_related those methods

--- a/instance/tests/test_person.py
+++ b/instance/tests/test_person.py
@@ -1,0 +1,28 @@
+from global_test_case import GlobalTestCase as TestCase
+from instance.models import PopoloPerson, WriteItInstance
+from contactos.models import ContactType, Contact
+
+
+class TestPopoloPerson(TestCase):
+    def setUp(self):
+        super(TestPopoloPerson, self).setUp()
+        self.person = PopoloPerson.objects.get(id=1)
+        self.contact_type, created = ContactType.objects.get_or_create(
+            name="e-mail", defaults={"label_name": "Electronic Mail"}
+        )
+        writeitinstance = WriteItInstance.objects.get(id=1)
+        self.contact = Contact.objects.create(
+            contact_type=self.contact_type,
+            value="test@email.com",
+            person=self.person,
+            writeitinstance=writeitinstance,
+        )
+
+    def test_has_contacts(self):
+        self.assertIn(self.person, PopoloPerson.objects.has_contacts())
+        self.assertNotIn(self.person, PopoloPerson.objects.doesnt_have_contacts())
+
+    def test_doesnt_have_contacts(self):
+        self.person.contact_set.all().delete()
+        self.assertIn(self.person, PopoloPerson.objects.doesnt_have_contacts())
+        self.assertNotIn(self.person, PopoloPerson.objects.has_contacts())

--- a/nuntium/api.py
+++ b/nuntium/api.py
@@ -19,7 +19,7 @@ from tastypie.paginator import Paginator
 from django.http import Http404, HttpResponseBadRequest
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
-from django.db.models import Count, Q
+from django.db.models import Count, Q, IntegerField, Sum, Case, When
 from tastypie.bundle import Bundle
 from tastypie.exceptions import Unauthorized
 
@@ -62,7 +62,8 @@ class PersonResource(ModelResource):
 
         filters = bundle.request.GET.copy()
         if 'contactable' in filters:
-            nb = Count('contact', filter=Q(is_bounced=False))
+            # Count the number of non-bounced contacts the person has
+            nb = Sum(Case(When(contact__is_bounced=False, then=1), default=0, output_field=IntegerField()))
             if filters['contactable'] == 'True':
                 result = result.annotate(not_bounced=nb).filter(not_bounced__gte=1)
             elif filters['contactable'] == 'False':

--- a/nuntium/api.py
+++ b/nuntium/api.py
@@ -62,12 +62,13 @@ class PersonResource(ModelResource):
         filters = bundle.request.GET.copy()
         if 'has_contacts' in filters:
             # Count the number of contacts the person has
-            if filters['has_contacts'] == 'True':
+            filters['has_contacts'] = filters['has_contacts'].lower()
+            if filters['has_contacts'] == 'true':
                 result = result.has_contacts()
-            elif filters['has_contacts'] == 'False':
+            elif filters['has_contacts'] == 'false':
                 result = result.doesnt_have_contacts()
             else:
-                raise InvalidFilterError("'has_contacts' field must either be 'True' or 'False'.")
+                raise InvalidFilterError("'has_contacts' field must either be 'true' or 'false'.")
 
         if 'instance_id' in filters:
             result = result.filter(writeit_instances__id=filters['instance_id'])

--- a/nuntium/api.py
+++ b/nuntium/api.py
@@ -60,14 +60,14 @@ class PersonResource(ModelResource):
         result = super(PersonResource, self).obj_get_list(bundle, **kwargs)
 
         filters = bundle.request.GET.copy()
-        if 'contactable' in filters:
+        if 'has_contacts' in filters:
             # Count the number of contacts the person has
-            if filters['contactable'] == 'True':
+            if filters['has_contacts'] == 'True':
                 result = result.has_contacts()
-            elif filters['contactable'] == 'False':
+            elif filters['has_contacts'] == 'False':
                 result = result.doesnt_have_contacts()
             else:
-                raise InvalidFilterError("'Contactable' field must either be 'True' or 'False'.")
+                raise InvalidFilterError("'has_contacts' field must either be 'True' or 'False'.")
 
         if 'instance_id' in filters:
             result = result.filter(writeit_instances__id=filters['instance_id'])

--- a/nuntium/api.py
+++ b/nuntium/api.py
@@ -69,6 +69,9 @@ class PersonResource(ModelResource):
             else:
                 raise InvalidFilterError("'Contactable' field must either be 'True' or 'False'.")
 
+        if 'instance_id' in filters:
+            result = result.filter(writeit_instances__id=filters['instance_id'])
+
         return result
 
 

--- a/nuntium/api.py
+++ b/nuntium/api.py
@@ -77,7 +77,6 @@ class PersonResource(ModelResource):
         bundle.data['resource_uri'] = bundle.obj.uri_for_api()
         bundle.data['popit_id'] = bundle.obj.old_popit_id
         bundle.data['popit_url'] = bundle.obj.uri_for_api()
-        bundle.data['contactable'] = bundle.obj.contactable
         return bundle
 
 

--- a/nuntium/api.py
+++ b/nuntium/api.py
@@ -60,6 +60,7 @@ class PersonResource(ModelResource):
         bundle.data['resource_uri'] = bundle.obj.uri_for_api()
         bundle.data['popit_id'] = bundle.obj.old_popit_id
         bundle.data['popit_url'] = bundle.obj.uri_for_api()
+        bundle.data['contactable'] = bundle.obj.contactable
         return bundle
 
 

--- a/nuntium/api.py
+++ b/nuntium/api.py
@@ -12,7 +12,7 @@ from tastypie.authorization import Authorization
 from django.core.exceptions import ObjectDoesNotExist
 from django.conf.urls import url
 from tastypie import fields
-from tastypie.exceptions import ImmediateHttpResponse
+from tastypie.exceptions import ImmediateHttpResponse, InvalidFilterError
 from tastypie import http
 from contactos.models import Contact
 from tastypie.paginator import Paginator
@@ -62,9 +62,14 @@ class PersonResource(ModelResource):
 
         filters = bundle.request.GET.copy()
         if 'contactable' in filters:
-            if filters['contactable']:
-                nb = Count('contact', filter=Q(is_bounced=False))
+            nb = Count('contact', filter=Q(is_bounced=False))
+            if filters['contactable'] == 'True':
                 result = result.annotate(not_bounced=nb).filter(not_bounced__gte=1)
+            elif filters['contactable'] == 'False':
+                result = result.annotate(not_bounced=nb).filter(not_bounced__lt=1)
+            else:
+                raise InvalidFilterError("'Contactable' field must either be 'True' or 'False'.")
+
         return result
 
 

--- a/nuntium/api.py
+++ b/nuntium/api.py
@@ -19,7 +19,6 @@ from tastypie.paginator import Paginator
 from django.http import Http404, HttpResponseBadRequest
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
-from django.db.models import Count, Q, IntegerField, Sum, Case, When
 from tastypie.bundle import Bundle
 from tastypie.exceptions import Unauthorized
 
@@ -62,12 +61,11 @@ class PersonResource(ModelResource):
 
         filters = bundle.request.GET.copy()
         if 'contactable' in filters:
-            # Count the number of non-bounced contacts the person has
-            nb = Sum(Case(When(contact__is_bounced=False, then=1), default=0, output_field=IntegerField()))
+            # Count the number of contacts the person has
             if filters['contactable'] == 'True':
-                result = result.annotate(not_bounced=nb).filter(not_bounced__gte=1)
+                result = result.has_contacts()
             elif filters['contactable'] == 'False':
-                result = result.annotate(not_bounced=nb).filter(not_bounced__lt=1)
+                result = result.doesnt_have_contacts()
             else:
                 raise InvalidFilterError("'Contactable' field must either be 'True' or 'False'.")
 

--- a/nuntium/api.py
+++ b/nuntium/api.py
@@ -2,8 +2,9 @@
 
 import json
 
-from tastypie.resources import ModelResource, ALL_WITH_RELATIONS, Resource
+from tastypie.resources import ModelResource, ALL_WITH_RELATIONS, ALL, Resource
 from instance.models import PopoloPerson, WriteItInstance
+from popolo.models import Identifier
 from .models import Message, Answer, \
     OutboundMessageIdentifier, OutboundMessage, Confirmation
 from tastypie.authentication import ApiKeyAuthentication
@@ -34,11 +35,26 @@ class PagePaginator(Paginator):
         return offset
 
 
+class IdentifierResource(ModelResource):
+    class Meta:
+        queryset = Identifier.objects.all()
+        resource_name = 'identifier'
+        filtering = {
+            'identifier': ALL,
+            'scheme': ALL,
+        }
+        allowed_methods = []
+
 class PersonResource(ModelResource):
+    identifiers = fields.ToManyField(IdentifierResource, 'identifiers', full=True)
+
     class Meta:
         queryset = PopoloPerson.objects.all()
         resource_name = 'person'
         authentication = ApiKeyAuthentication()
+        filtering = {
+            'identifiers': ALL_WITH_RELATIONS,
+        }
 
     def dehydrate(self, bundle):
         bundle.data['resource_uri'] = bundle.obj.uri_for_api()

--- a/nuntium/tests/api/person_resource_test.py
+++ b/nuntium/tests/api/person_resource_test.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from django.core.management import call_command
-from instance.models import WriteItInstance
 from tastypie.test import ResourceTestCase, TestApiClient
 from django.contrib.auth.models import User
 from django.db.models import Count
@@ -13,9 +12,6 @@ class PersonResourceTestCase(ResourceTestCase):
         super(PersonResourceTestCase, self).setUp()
         call_command("loaddata", "example_data", verbosity=0)
         self.user = User.objects.get(id=1)
-        self.writeitinstance = WriteItInstance.objects.create(
-            name=u"a test", slug=u"a-test", owner=self.user
-        )
         self.api_client = TestApiClient()
 
         self.data = {
@@ -77,7 +73,7 @@ class PersonResourceTestCase(ResourceTestCase):
         self.assertValidJSONResponse(response)
 
         persons = self.deserialize(response)["objects"]
-        self.assertEqual(len(persons), Person.objects.has_contacts().count())
+        self.assertEqual(len(persons), 3)
 
     def test_filter_list_of_persons_by_does_not_have_contacts(self):
         url = "/api/v1/person/?has_contacts=False"
@@ -86,7 +82,7 @@ class PersonResourceTestCase(ResourceTestCase):
         self.assertValidJSONResponse(response)
 
         persons = self.deserialize(response)["objects"]
-        self.assertEqual(len(persons), Person.objects.doesnt_have_contacts().count())
+        self.assertEqual(len(persons), 1)
 
     def test_filter_invalid_has_contacts_value(self):
         url = "/api/v1/person/?has_contacts=something-else"
@@ -95,10 +91,10 @@ class PersonResourceTestCase(ResourceTestCase):
         self.assertHttpBadRequest(response)
 
     def test_filter_list_of_persons_by_instance(self):
-        url = "/api/v1/person/?instance_id=%d" % self.writeitinstance.id
+        url = "/api/v1/person/?instance_id=%d" % 1
         response = self.api_client.get(url, authentication=self.get_credentials())
 
         self.assertValidJSONResponse(response)
 
         persons = self.deserialize(response)["objects"]
-        self.assertEqual(len(persons), self.writeitinstance.persons.count())
+        self.assertEqual(len(persons), 1)

--- a/nuntium/tests/api/person_resource_test.py
+++ b/nuntium/tests/api/person_resource_test.py
@@ -71,7 +71,7 @@ class PersonResourceTestCase(ResourceTestCase):
         self.assertEqual(person.id, persons[0]["id"])
 
     def test_filter_list_of_persons_by_is_contactable(self):
-        url = "/api/v1/person/?contactable=True"
+        url = "/api/v1/person/?has_contacts=True"
         response = self.api_client.get(url, authentication=self.get_credentials())
 
         self.assertValidJSONResponse(response)
@@ -80,7 +80,7 @@ class PersonResourceTestCase(ResourceTestCase):
         self.assertEqual(len(persons), Person.objects.has_contacts().count())
 
     def test_filter_list_of_persons_by_is_not_contactable(self):
-        url = "/api/v1/person/?contactable=False"
+        url = "/api/v1/person/?has_contacts=False"
         response = self.api_client.get(url, authentication=self.get_credentials())
 
         self.assertValidJSONResponse(response)

--- a/nuntium/tests/api/person_resource_test.py
+++ b/nuntium/tests/api/person_resource_test.py
@@ -18,6 +18,9 @@ class PersonResourceTestCase(ResourceTestCase):
         )
         self.api_client = TestApiClient()
 
+        self.person = Person.objects.create(name='Tester')
+        self.writeitinstance.add_person(self.person)
+
         self.data = {
             "format": "json",
             "username": self.user.username,
@@ -87,3 +90,12 @@ class PersonResourceTestCase(ResourceTestCase):
 
         persons = self.deserialize(response)["objects"]
         self.assertEqual(len(persons), Person.objects.doesnt_have_contacts().count())
+
+    def test_filter_list_of_persons_by_instance(self):
+        url = "/api/v1/person/?instance_id=%d" % self.writeitinstance.id
+        response = self.api_client.get(url, authentication=self.get_credentials())
+
+        self.assertValidJSONResponse(response)
+
+        persons = self.deserialize(response)["objects"]
+        self.assertEqual(len(persons), self.writeitinstance.persons.count())

--- a/nuntium/tests/api/person_resource_test.py
+++ b/nuntium/tests/api/person_resource_test.py
@@ -70,7 +70,7 @@ class PersonResourceTestCase(ResourceTestCase):
         self.assertEqual(1, len(persons))
         self.assertEqual(person.id, persons[0]["id"])
 
-    def test_filter_list_of_persons_by_is_contactable(self):
+    def test_filter_list_of_persons_by_has_contacts(self):
         url = "/api/v1/person/?has_contacts=True"
         response = self.api_client.get(url, authentication=self.get_credentials())
 
@@ -79,7 +79,7 @@ class PersonResourceTestCase(ResourceTestCase):
         persons = self.deserialize(response)["objects"]
         self.assertEqual(len(persons), Person.objects.has_contacts().count())
 
-    def test_filter_list_of_persons_by_is_not_contactable(self):
+    def test_filter_list_of_persons_by_does_not_have_contacts(self):
         url = "/api/v1/person/?has_contacts=False"
         response = self.api_client.get(url, authentication=self.get_credentials())
 
@@ -87,6 +87,12 @@ class PersonResourceTestCase(ResourceTestCase):
 
         persons = self.deserialize(response)["objects"]
         self.assertEqual(len(persons), Person.objects.doesnt_have_contacts().count())
+
+    def test_filter_invalid_has_contacts_value(self):
+        url = "/api/v1/person/?has_contacts=something-else"
+        response = self.api_client.get(url, authentication=self.get_credentials())
+
+        self.assertHttpBadRequest(response)
 
     def test_filter_list_of_persons_by_instance(self):
         url = "/api/v1/person/?instance_id=%d" % self.writeitinstance.id

--- a/nuntium/tests/api/person_resource_test.py
+++ b/nuntium/tests/api/person_resource_test.py
@@ -18,9 +18,6 @@ class PersonResourceTestCase(ResourceTestCase):
         )
         self.api_client = TestApiClient()
 
-        self.person = Person.objects.create(name='Tester')
-        self.writeitinstance.add_person(self.person)
-
         self.data = {
             "format": "json",
             "username": self.user.username,

--- a/nuntium/tests/api/person_resource_test.py
+++ b/nuntium/tests/api/person_resource_test.py
@@ -3,40 +3,87 @@ from django.core.management import call_command
 from instance.models import WriteItInstance
 from tastypie.test import ResourceTestCase, TestApiClient
 from django.contrib.auth.models import User
-from popolo.models import Person
+from django.db.models import Count
+from popolo.models import Identifier
+from instance.models import PopoloPerson as Person
 
 
 class PersonResourceTestCase(ResourceTestCase):
     def setUp(self):
         super(PersonResourceTestCase, self).setUp()
-        call_command('loaddata', 'example_data', verbosity=0)
+        call_command("loaddata", "example_data", verbosity=0)
         self.user = User.objects.get(id=1)
-        self.writeitinstance = WriteItInstance.objects.create(name=u"a test", slug=u"a-test", owner=self.user)
+        self.writeitinstance = WriteItInstance.objects.create(
+            name=u"a test", slug=u"a-test", owner=self.user
+        )
         self.api_client = TestApiClient()
 
-        self.data = {'format': 'json', 'username': self.user.username, 'api_key': self.user.api_key.key}
+        self.data = {
+            "format": "json",
+            "username": self.user.username,
+            "api_key": self.user.api_key.key,
+        }
 
     def get_credentials(self):
-        credentials = self.create_apikey(username=self.user.username, api_key=self.user.api_key.key)
+        credentials = self.create_apikey(
+            username=self.user.username, api_key=self.user.api_key.key
+        )
         return credentials
 
-    def test_get_list_of_messages(self):
-        url = '/api/v1/person/'
+    def test_get_list_of_persons(self):
+        url = "/api/v1/person/"
         response = self.api_client.get(url, authentication=self.get_credentials())
 
         self.assertValidJSONResponse(response)
 
-        persons = self.deserialize(response)['objects']
+        persons = self.deserialize(response)["objects"]
         self.assertEqual(len(persons), Person.objects.count())  # All the instances
 
     def test_unauthorized_list_of_persons(self):
-        url = '/api/v1/person/'
+        url = "/api/v1/person/"
         response = self.api_client.get(url)
 
         self.assertHttpUnauthorized(response)
 
     def test_the_remote_url_of_the_person_points_to_its_popit_instance(self):
-        url = '/api/v1/person/'
+        url = "/api/v1/person/"
         response = self.api_client.get(url, authentication=self.get_credentials())
-        persons = self.deserialize(response)['objects']
-        self.assertEquals(persons[0]['popit_url'], persons[0]['resource_uri'])
+        persons = self.deserialize(response)["objects"]
+        self.assertEquals(persons[0]["popit_url"], persons[0]["resource_uri"])
+
+    def test_filter_list_of_persons_by_identifier(self):
+        id_count = Count("identifiers")
+        person = (
+            Person.objects.annotate(id_count=id_count).filter(id_count__gte=1).first()
+        )
+        identifier = person.identifiers.first()
+
+        url = "/api/v1/person/?identifiers__identifier=%s&identifiers__scheme=%s" % (
+            identifier.identifier,
+            identifier.scheme,
+        )
+        response = self.api_client.get(url, authentication=self.get_credentials())
+
+        self.assertValidJSONResponse(response)
+
+        persons = self.deserialize(response)["objects"]
+        self.assertEqual(1, len(persons))
+        self.assertEqual(person.id, persons[0]["id"])
+
+    def test_filter_list_of_persons_by_is_contactable(self):
+        url = "/api/v1/person/?contactable=True"
+        response = self.api_client.get(url, authentication=self.get_credentials())
+
+        self.assertValidJSONResponse(response)
+
+        persons = self.deserialize(response)["objects"]
+        self.assertEqual(len(persons), Person.objects.has_contacts().count())
+
+    def test_filter_list_of_persons_by_is_not_contactable(self):
+        url = "/api/v1/person/?contactable=False"
+        response = self.api_client.get(url, authentication=self.get_credentials())
+
+        self.assertValidJSONResponse(response)
+
+        persons = self.deserialize(response)["objects"]
+        self.assertEqual(len(persons), Person.objects.doesnt_have_contacts().count())

--- a/nuntium/user_section/tests/template_tags_tests.py
+++ b/nuntium/user_section/tests/template_tags_tests.py
@@ -41,7 +41,7 @@ class ListContactsTemplateTag(TestCase):
             "people": people
             })
         rendered = t.render(c)
-        self.assertEquals(u'Pedro, Marcel and Felipe', rendered)
+        self.assertEquals(u'Pedro, Marcel, Felipe and Philippa', rendered)
 
     def test_join_with_commas_another_language(self):
         '''
@@ -53,7 +53,7 @@ class ListContactsTemplateTag(TestCase):
             "people": people
             })
         rendered = t.render(c)
-        self.assertEquals(u'Pedro, Marcel, Felipe', rendered)
+        self.assertEquals(u'Pedro, Marcel, Felipe, Philippa', rendered)
 
     def test_join_with_commas_english(self):
         '''
@@ -65,7 +65,7 @@ class ListContactsTemplateTag(TestCase):
             "people": people
             })
         rendered = t.render(c)
-        self.assertEquals(u'Pedro, Marcel and Felipe', rendered)
+        self.assertEquals(u'Pedro, Marcel, Felipe and Philippa', rendered)
 
     def test_get_url_using_subdomain(self):
         '''


### PR DESCRIPTION
[Pivotal](https://www.pivotaltracker.com/story/show/172920709)

This PR adds the capability of being able to filter people by their identifiers and by whether they are "contactable" in WriteInPublic.

In this case "contactable" means that there exists a "Contact" value for the person in the database.

For a while, I thought that we should also check whether the contact has bounced or not, but I realised that then we might show the error message on the PA draft form for more than 24 hours.

Example of what a request will look like:

```
GET http://127.0.0.1.xip.io:8001/api/v1/person/?format=json&username=delena&api_key=3e345bfa2e6606ca0e6cf23e44705b39b24ab1e0&identifiers__identifier=9684&identifiers__scheme=popolo:person&contactable=True

{
    "meta": {
        "limit": 20,
        "next": null,
        "offset": 0,
        "previous": null,
        "total_count": 1
    },
    "objects": [
        {
            "additional_name": "",
            "biography": "",
            "birth_date": "",
            "created_at": "2020-06-04T04:54:11.320858",
            "death_date": "",
            "email": "aseabi@parliament.gov.za",
            "end_date": null,
            "family_name": "",
            "gender": "",
            "given_name": "",
            "honorific_prefix": "",
            "honorific_suffix": "",
            "id": 319,
            "identifiers": [
                {
                    "id": 640,
                    "identifier": "9684",
                    "object_id": 319,
                    "resource_uri": "",
                    "scheme": "popolo:person"
                },
                {
                    "id": 641,
                    "identifier": "https://pa.org.za/api/national-assembly/popolo.json#person-9684",
                    "object_id": 319,
                    "resource_uri": "",
                    "scheme": "popolo_uri"
                }
            ],
            "image": null,
            "name": "Albert Mammoga Seabi",
            "national_identity": null,
            "patronymic_name": "",
            "popit_id": null,
            "popit_url": "https://pa.org.za/api/national-assembly/popolo.json#person-9684",
            "resource_uri": "https://pa.org.za/api/national-assembly/popolo.json#person-9684",
            "sort_name": "",
            "start_date": null,
            "summary": "",
            "updated_at": "2020-06-09T08:43:45.466050"
        }
    ]
}
```