### PR TITLE
Fix OutboundMessageIdentifier error for multiple input emails

### DIFF
--- a/mailit/bin/handleemail.py
+++ b/mailit/bin/handleemail.py
@@ -167,7 +167,7 @@ class EmailHandler(FroideEmailParser):
 
     def save_raw_email(self, lines):
         return RawIncomingEmail.objects.create(content=lines)
-    
+
     def instanciate_answer(self, lines):
         answer = self.answer_class()
         msgtxt = ''.join(lines)

--- a/mailit/bin/handleemail.py
+++ b/mailit/bin/handleemail.py
@@ -167,8 +167,8 @@ class EmailHandler(FroideEmailParser):
 
         the_recipient = re.sub(r"\n", "", the_recipient)
 
-        regex = re.compile(r".*[\+\-](.*)@.*")
-        the_match = regex.match(the_recipient)
+        regex = re.compile(r"\w+[\+\-](\w+?)@")
+        the_match = regex.search(the_recipient)
         if the_match is None:
             raise CouldNotFindIdentifier
         answer.email_to = the_recipient

--- a/mailit/tests/email_parser/incoming_mail_tests.py
+++ b/mailit/tests/email_parser/incoming_mail_tests.py
@@ -14,7 +14,10 @@ from global_test_case import GlobalTestCase as TestCase
 from global_test_case import ResourceGlobalTestCase as ResourceTestCase
 from mailit.answer import OutboundMessageAnswer
 from mailit.bin import config
-from mailit.bin.handleemail import EmailHandler, EmailAnswer, ApiKeyAuth
+from mailit.bin.handleemail import (
+    EmailHandler, EmailAnswer, ApiKeyAuth, get_outbound_message_identifier
+)
+from mailit.exceptions import CouldNotFindIdentifier
 from mailit.models import BouncedMessageRecord
 
 
@@ -95,6 +98,24 @@ class DoesNotIncludeTheIdentifierInTheContent(TestCase):
             self.answer.send_back()
 
             post.assert_called_with(self.where_to_post_creation_of_the_answer, data=data, headers=expected_headers)
+
+
+class GetOutboundMessageIdentifierTestCase(ResourceTestCase):
+    def test_get_identifier_from_one_email(self):
+        recipient = "test+12345@gmail.com"
+        result = get_outbound_message_identifier(recipient)
+        self.assertEquals(result, "12345")
+
+    def test_raise_exception_for_no_identifier_found(self):
+        recipient = "test@gmail.com"
+
+        with self.assertRaises(CouldNotFindIdentifier):
+            result = get_outbound_message_identifier(recipient)
+
+    def test_get_identifier_from_multiple_emails(self):
+        recipient = "Zene Van niekerk <south-africa-assembly+25459cface3411eaa5e00242ac110006@writeinpublic.pa.org.za>, Nomsa Tarabella-Marchesi <nomsa_marchesi@hotmail.com>"
+        result = get_outbound_message_identifier(recipient)
+        self.assertEquals(result, "25459cface3411eaa5e00242ac110006")
 
 
 class IncomingEmailHandlerTestCase(ResourceTestCase):

--- a/mailit/tests/email_parser/incoming_mail_tests.py
+++ b/mailit/tests/email_parser/incoming_mail_tests.py
@@ -100,7 +100,7 @@ class DoesNotIncludeTheIdentifierInTheContent(TestCase):
             post.assert_called_with(self.where_to_post_creation_of_the_answer, data=data, headers=expected_headers)
 
 
-class GetOutboundMessageIdentifierTestCase(ResourceTestCase):
+class GetOutboundMessageIdentifierTestCase(TestCase):
     def test_get_identifier_from_one_email(self):
         recipient = "test+12345@gmail.com"
         result = get_outbound_message_identifier(recipient)

--- a/mailit/tests/sendgrid_webhook_test.py
+++ b/mailit/tests/sendgrid_webhook_test.py
@@ -108,5 +108,5 @@ class IncomingMailTestCase(TestCase):
         self.assertEquals(len(mail.outbox[0].attachments), 1)
 
         # Should log the error
-        args = logger_patch.error.call_args[0][0]
+        args = logger_patch.exception.call_args[0][0]
         self.assertEquals('OutboundMessageIdentifier matching query does not exist.', str(args))

--- a/mailit/views.py
+++ b/mailit/views.py
@@ -77,7 +77,7 @@ class IncomingMail(View):
         except CouldNotFindIdentifier as e:
             logger.warn(e)
         except OutboundMessageIdentifier.DoesNotExist as e:
-            logger.error(e)
+            logger.exception(e)
             tb = traceback.format_exc()
             send_error_email(email, tb)
         except Exception as e:


### PR DESCRIPTION
Identifies the OutboundMessageIdentifier even when there are multiple recipients. 

The "To" field for multiple recipients would look something like this:

```
Zene Van niekerk <south-africa-assembly+25459cface3411eaa5e00242ac110006@writeinpublic.pa.org.za>, 
Nomsa Tarabella-Marchesi <nomsa_marchesi@hotmail.com>
```

Our current regex only caters for a single recipient email address. That is what caused [this](https://sentry.io/organizations/openupsa/issues/1776840709/?project=5239183&query=is%3Aunresolved) error.

[Pivotal link](https://www.pivotaltracker.com/story/show/174063912)

This fix will try to find the first email address that contains `+` and try to use the part between the `+` and the `@` as the identifier. 

There is still the possibility of getting an error when there is another email address that contains a `+` and it is before our incoming mail address. For example, if the "To" field is: `delena+1@gmail.com,  south-africa-assembly+25459cface3411eaa5e00242ac110006@writeinpublic.pa.org.za>`, the identifier would be identified as `1`. I'm not sure if it would be worth spending the time on catering for such a fringe case though.