### PR TITLE
Use no-reply email address for answer notifications

### DIFF
--- a/nuntium/models.py
+++ b/nuntium/models.py
@@ -339,7 +339,11 @@ def send_new_answer_payload(sender, instance, created, **kwargs):
         text_content = new_answer_template.get_content_template().format(**context)
         html_content = new_answer_template.template_html.format(**escape_dictionary_values(context))
 
-        if settings.SEND_ALL_EMAILS_FROM_DEFAULT_FROM_EMAIL:
+        if settings.DEFAULT_NO_REPLY_EMAIL:
+            # We prefer to send answer notifications from the no-reply email
+            # address so that it's clear to users that they can't reply to it.
+            from_email = settings.DEFAULT_NO_REPLY_EMAIL
+        elif settings.SEND_ALL_EMAILS_FROM_DEFAULT_FROM_EMAIL:
             from_email = settings.DEFAULT_FROM_EMAIL
         else:
             from_domain = writeitinstance.config.custom_from_domain or settings.DEFAULT_FROM_DOMAIN

--- a/nuntium/models.py
+++ b/nuntium/models.py
@@ -339,16 +339,12 @@ def send_new_answer_payload(sender, instance, created, **kwargs):
         text_content = new_answer_template.get_content_template().format(**context)
         html_content = new_answer_template.template_html.format(**escape_dictionary_values(context))
 
-        if settings.DEFAULT_NO_REPLY_EMAIL:
-            # We prefer to send answer notifications from the no-reply email
-            # address so that it's clear to users that they can't reply to it.
-            from_email = settings.DEFAULT_NO_REPLY_EMAIL
-        elif settings.SEND_ALL_EMAILS_FROM_DEFAULT_FROM_EMAIL:
+        if settings.SEND_ALL_EMAILS_FROM_DEFAULT_FROM_EMAIL:
             from_email = settings.DEFAULT_FROM_EMAIL
         else:
             from_domain = writeitinstance.config.custom_from_domain or settings.DEFAULT_FROM_DOMAIN
             from_email = "%s@%s" % (
-                writeitinstance.slug,
+                settings.DEFAULT_NO_REPLY_LOCAL_PART,
                 from_domain,
                 )
 

--- a/nuntium/tests/subscribers_test.py
+++ b/nuntium/tests/subscribers_test.py
@@ -168,7 +168,7 @@ class NewAnswerNotificationToSubscribers(TestCase):
 
         self.assertEquals(
             mail.outbox[0].from_email,
-            self.instance.slug + "@" + settings.DEFAULT_FROM_DOMAIN,
+            settings.DEFAULT_NO_REPLY_EMAIL,
             )
 
     def test_when_an_answer_is_created_then_a_mail_is_sent_to_the_subscribers_with_real_name(self):
@@ -179,7 +179,7 @@ class NewAnswerNotificationToSubscribers(TestCase):
 
         self.assertEquals(len(mail.outbox), 1)
         email_to_check = mail.outbox[0]
-        expected_email_address = self.message.writeitinstance.slug + "@" + settings.DEFAULT_FROM_DOMAIN
+        expected_email_address = settings.DEFAULT_NO_REPLY_EMAIL
         expected_real_name = u'☃ The Snowman ☃'
         expected_from = u'{real_name} <{email}>'.format(
             real_name=expected_real_name,
@@ -230,9 +230,9 @@ class NewAnswerNotificationToSubscribers(TestCase):
 
     @override_settings(SEND_ALL_EMAILS_FROM_DEFAULT_FROM_EMAIL=True)
     def test_send_subscribers_notice_from_a_single_unified_email(self):
-        '''Send emails from default from email'''
+        '''Send emails from default no-reply email'''
         self.create_a_new_answer()
-        self.assertEquals(mail.outbox[0].from_email, settings.DEFAULT_FROM_EMAIL)
+        self.assertEquals(mail.outbox[0].from_email, settings.DEFAULT_NO_REPLY_EMAIL)
 
     def test_owner_of_the_instance_is_notified_when_a_new_answer_comes_in(self):
         self.instance.config.notify_owner_when_new_answer = True
@@ -245,8 +245,10 @@ class NewAnswerNotificationToSubscribers(TestCase):
         self.assertEquals(len(mail.outbox[1].to), 1)
         self.assertEquals(mail.outbox[1].to[0], user.email)
 
-    def test_notify_the_owner_using_custom_domain(self):
-        '''Using custom domain to notify the owner of an instance if custom config is provided'''
+    def test_notify_the_owner_using_no_reply_even_ifcustom_domain(self):
+        '''
+        Still use default no-reply email to notify the owner of an instance 
+        even if custom config is provided'''
         config = self.instance.config
         config.custom_from_domain = "custom.domain.cl"
         config.email_host = 'cuttlefish.au.org'
@@ -262,7 +264,7 @@ class NewAnswerNotificationToSubscribers(TestCase):
         sent_mail = mail.outbox[1]
         self.assertEquals(
             sent_mail.from_email,
-            self.instance.slug + "@" + config.custom_from_domain,
+            settings.DEFAULT_NO_REPLY_EMAIL,
             )
         connection = sent_mail.connection
         self.assertEquals(connection.host, config.email_host)
@@ -273,8 +275,11 @@ class NewAnswerNotificationToSubscribers(TestCase):
 
         #I didn't have to change anything =/
 
-    def test_send_subscriber_mail_from_custom_domain(self):
-        '''The mail to the subscriber if new answer exists from a custom domain'''
+    def test_send_subscriber_mail_from_no_reply_even_if_custom_domain(self):
+        '''
+        The mail to the subscriber if new answer exists from the default 
+        no reply email even if the instance has a custom domain.
+        '''
         config = self.instance.config
         config.custom_from_domain = "custom.domain.cl"
         config.email_host = 'cuttlefish.au.org'
@@ -288,7 +293,7 @@ class NewAnswerNotificationToSubscribers(TestCase):
         sent_mail = mail.outbox[0]
         self.assertEquals(
             sent_mail.from_email,
-            self.instance.slug + "@" + config.custom_from_domain,
+            settings.DEFAULT_NO_REPLY_EMAIL,
             )
         connection = sent_mail.connection
         self.assertEquals(connection.host, config.email_host)

--- a/nuntium/tests/subscribers_test.py
+++ b/nuntium/tests/subscribers_test.py
@@ -168,7 +168,7 @@ class NewAnswerNotificationToSubscribers(TestCase):
 
         self.assertEquals(
             mail.outbox[0].from_email,
-            settings.DEFAULT_NO_REPLY_EMAIL,
+            settings.DEFAULT_NO_REPLY_LOCAL_PART + "@" + settings.DEFAULT_FROM_DOMAIN,
             )
 
     def test_when_an_answer_is_created_then_a_mail_is_sent_to_the_subscribers_with_real_name(self):
@@ -179,7 +179,7 @@ class NewAnswerNotificationToSubscribers(TestCase):
 
         self.assertEquals(len(mail.outbox), 1)
         email_to_check = mail.outbox[0]
-        expected_email_address = settings.DEFAULT_NO_REPLY_EMAIL
+        expected_email_address = settings.DEFAULT_NO_REPLY_LOCAL_PART + "@" + settings.DEFAULT_FROM_DOMAIN
         expected_real_name = u'☃ The Snowman ☃'
         expected_from = u'{real_name} <{email}>'.format(
             real_name=expected_real_name,
@@ -230,9 +230,9 @@ class NewAnswerNotificationToSubscribers(TestCase):
 
     @override_settings(SEND_ALL_EMAILS_FROM_DEFAULT_FROM_EMAIL=True)
     def test_send_subscribers_notice_from_a_single_unified_email(self):
-        '''Send emails from default no-reply email'''
+        '''Send emails from default from email'''
         self.create_a_new_answer()
-        self.assertEquals(mail.outbox[0].from_email, settings.DEFAULT_NO_REPLY_EMAIL)
+        self.assertEquals(mail.outbox[0].from_email, settings.DEFAULT_FROM_EMAIL)
 
     def test_owner_of_the_instance_is_notified_when_a_new_answer_comes_in(self):
         self.instance.config.notify_owner_when_new_answer = True
@@ -245,10 +245,8 @@ class NewAnswerNotificationToSubscribers(TestCase):
         self.assertEquals(len(mail.outbox[1].to), 1)
         self.assertEquals(mail.outbox[1].to[0], user.email)
 
-    def test_notify_the_owner_using_no_reply_even_ifcustom_domain(self):
-        '''
-        Still use default no-reply email to notify the owner of an instance 
-        even if custom config is provided'''
+    def test_notify_the_owner_using_custom_domain(self):
+        '''Using custom domain to notify the owner of an instance if custom config is provided'''
         config = self.instance.config
         config.custom_from_domain = "custom.domain.cl"
         config.email_host = 'cuttlefish.au.org'
@@ -264,7 +262,7 @@ class NewAnswerNotificationToSubscribers(TestCase):
         sent_mail = mail.outbox[1]
         self.assertEquals(
             sent_mail.from_email,
-            settings.DEFAULT_NO_REPLY_EMAIL,
+            settings.DEFAULT_NO_REPLY_LOCAL_PART + "@" + config.custom_from_domain,
             )
         connection = sent_mail.connection
         self.assertEquals(connection.host, config.email_host)
@@ -275,11 +273,8 @@ class NewAnswerNotificationToSubscribers(TestCase):
 
         #I didn't have to change anything =/
 
-    def test_send_subscriber_mail_from_no_reply_even_if_custom_domain(self):
-        '''
-        The mail to the subscriber if new answer exists from the default 
-        no reply email even if the instance has a custom domain.
-        '''
+    def test_send_subscriber_mail_from_custom_domain(self):
+        '''The mail to the subscriber if new answer exists from a custom domain'''
         config = self.instance.config
         config.custom_from_domain = "custom.domain.cl"
         config.email_host = 'cuttlefish.au.org'
@@ -293,7 +288,7 @@ class NewAnswerNotificationToSubscribers(TestCase):
         sent_mail = mail.outbox[0]
         self.assertEquals(
             sent_mail.from_email,
-            settings.DEFAULT_NO_REPLY_EMAIL,
+            settings.DEFAULT_NO_REPLY_LOCAL_PART + "@" + config.custom_from_domain,
             )
         connection = sent_mail.connection
         self.assertEquals(connection.host, config.email_host)

--- a/writeit/settings.py
+++ b/writeit/settings.py
@@ -340,7 +340,7 @@ TEST_POPIT_API_URL = "http://%s.%s.xip.io:%s/api/v0.1/export.json" % (
 # Email settings
 DEFAULT_FROM_EMAIL = env.str("DEFAULT_FROM_EMAIL", 'south-africa-assembly@writeinpublic.pa.org.za')
 
-DEFAULT_NO_REPLY_LOCAL_PART = env('DEFAULT_NO_REPLY_LOCAL_PART', 'no-reply')
+DEFAULT_NO_REPLY_LOCAL_PART = env.str('DEFAULT_NO_REPLY_LOCAL_PART', 'no-reply')
 
 # DEFAULT_FROM_DOMAIN
 DEFAULT_FROM_DOMAIN = env.str("DEFAULT_FROM_DOMAIN", 'writeinpublic.pa.org.za')

--- a/writeit/settings.py
+++ b/writeit/settings.py
@@ -336,11 +336,15 @@ TEST_POPIT_API_URL = "http://%s.%s.xip.io:%s/api/v0.1/export.json" % (
     TEST_POPIT_API_PORT,
     )
 
+
 # Email settings
-DEFAULT_FROM_EMAIL = env.str("DEFAULT_FROM_EMAIL", 'mailer@example.com')
+DEFAULT_FROM_EMAIL = env.str("DEFAULT_FROM_EMAIL", 'no-reply@writeinpublic.pa.org.za')
 
 # DEFAULT_FROM_DOMAIN
-DEFAULT_FROM_DOMAIN = env.str("DEFAULT_FROM_DOMAIN", 'mailit.ciudadanointeligente.org')
+DEFAULT_FROM_DOMAIN = env.str("DEFAULT_FROM_DOMAIN", 'writeinpublic.pa.org.za')
+
+# No-reply email address
+DEFAULT_NO_REPLY_EMAIL = env.str("DEFAULT_NO_REPLY_EMAIL", 'mailer@example.com')
 
 # In some cases it is needed that all emails come from one single
 # email address, such is the case when you have just verified a single sender

--- a/writeit/settings.py
+++ b/writeit/settings.py
@@ -340,11 +340,10 @@ TEST_POPIT_API_URL = "http://%s.%s.xip.io:%s/api/v0.1/export.json" % (
 # Email settings
 DEFAULT_FROM_EMAIL = env.str("DEFAULT_FROM_EMAIL", 'south-africa-assembly@writeinpublic.pa.org.za')
 
+DEFAULT_NO_REPLY_LOCAL_PART = env('DEFAULT_NO_REPLY_LOCAL_PART', 'no-reply')
+
 # DEFAULT_FROM_DOMAIN
 DEFAULT_FROM_DOMAIN = env.str("DEFAULT_FROM_DOMAIN", 'writeinpublic.pa.org.za')
-
-# No-reply email address
-DEFAULT_NO_REPLY_EMAIL = env.str("DEFAULT_NO_REPLY_EMAIL", 'no-reply@writeinpublic.pa.org.za')
 
 # In some cases it is needed that all emails come from one single
 # email address, such is the case when you have just verified a single sender

--- a/writeit/settings.py
+++ b/writeit/settings.py
@@ -338,13 +338,13 @@ TEST_POPIT_API_URL = "http://%s.%s.xip.io:%s/api/v0.1/export.json" % (
 
 
 # Email settings
-DEFAULT_FROM_EMAIL = env.str("DEFAULT_FROM_EMAIL", 'no-reply@writeinpublic.pa.org.za')
+DEFAULT_FROM_EMAIL = env.str("DEFAULT_FROM_EMAIL", 'south-africa-assembly@writeinpublic.pa.org.za')
 
 # DEFAULT_FROM_DOMAIN
 DEFAULT_FROM_DOMAIN = env.str("DEFAULT_FROM_DOMAIN", 'writeinpublic.pa.org.za')
 
 # No-reply email address
-DEFAULT_NO_REPLY_EMAIL = env.str("DEFAULT_NO_REPLY_EMAIL", 'mailer@example.com')
+DEFAULT_NO_REPLY_EMAIL = env.str("DEFAULT_NO_REPLY_EMAIL", 'no-reply@writeinpublic.pa.org.za')
 
 # In some cases it is needed that all emails come from one single
 # email address, such is the case when you have just verified a single sender


### PR DESCRIPTION
[Pivotal](https://www.pivotaltracker.com/n/projects/2397264/stories/174314194)

Adds a new Django setting and environment variable, `DEFAULT_NO_REPLY_LOCAL_PART` with default "no-reply". Since every instance has a `custom_from_domain` value, we send answer notifications to `DEFAULT_NO_REPLY_LOCAL_PART`@`instance.custom_from_domain` instead of `instance.slug`@`instance.custom_from_domain` like we used to.

Tried it out locally and it worked perfectly. Didn't end up in spam.

![2020-10-16-21:23](https://user-images.githubusercontent.com/4767109/96300573-05496680-0ff6-11eb-9880-bb7fed86f0b1.png)
![2020-10-16-21:23_1](https://user-images.githubusercontent.com/4767109/96300575-07132a00-0ff6-11eb-83ec-80a8666effdd.png)
